### PR TITLE
Use Caught0 instead of Caught

### DIFF
--- a/tla/HPaxos_2.tla
+++ b/tla/HPaxos_2.tla
@@ -41,20 +41,8 @@ CONSTANT WellFormed2a(_)
 
     \* The acceptor is _caught_ in a message x if the transitive references of x
     \* include evidence such as two different messages both signed by the acceptor,
-    \* which have equal previous messages.
+    \* which have equal previous messages (which may equal the NonMessage).
     CaughtMsg(x) ==
-        { m \in Tran(x) :
-            /\ m.type = "acceptor"
-            /\ \E m1 \in Tran(x) :
-                /\ m1.type = "acceptor"
-                /\ m.acc = m1.acc
-                /\ m # m1
-                /\ m \notin PrevTran(m1)
-                /\ m1 \notin PrevTran(m) }
-
-    Caught(x) == { m.acc : m \in CaughtMsg(x) }
-
-    CaughtMsg0(x) ==
         { m \in Tran(x) :
             /\ m.type = "acceptor"
             /\ \E m1 \in Tran(x) :
@@ -63,7 +51,7 @@ CONSTANT WellFormed2a(_)
                 /\ m # m1
                 /\ m.prev = m1.prev }
 
-    Caught0(x) == { m.acc : m \in CaughtMsg0(x) }
+    Caught(x) == { m.acc : m \in CaughtMsg(x) }
 
     \* Connected
     ConByQuorum(alpha, beta, x, S) == \* alpha : Learner, beta : Learner, x : 1b, S \in ByzQuorum
@@ -225,7 +213,7 @@ CONSTANT WellFormed2a(_)
 }
 
 ****************************************************************************)
-\* BEGIN TRANSLATION (chksum(pcal) = "71812e9f" /\ chksum(tla) = "f217c7c2")
+\* BEGIN TRANSLATION (chksum(pcal) = "c07d66a2" /\ chksum(tla) = "dc25c029")
 VARIABLES msgs, known_msgs, recent_msgs, prev_msg, decision, BVal
 
 (* define statement *)
@@ -260,21 +248,9 @@ CaughtMsg(x) ==
             /\ m1.type = "acceptor"
             /\ m.acc = m1.acc
             /\ m # m1
-            /\ m \notin PrevTran(m1)
-            /\ m1 \notin PrevTran(m) }
-
-Caught(x) == { m.acc : m \in CaughtMsg(x) }
-
-CaughtMsg0(x) ==
-    { m \in Tran(x) :
-        /\ m.type = "acceptor"
-        /\ \E m1 \in Tran(x) :
-            /\ m1.type = "acceptor"
-            /\ m.acc = m1.acc
-            /\ m # m1
             /\ m.prev = m1.prev }
 
-Caught0(x) == { m.acc : m \in CaughtMsg0(x) }
+Caught(x) == { m.acc : m \in CaughtMsg(x) }
 
 
 ConByQuorum(alpha, beta, x, S) ==
@@ -379,7 +355,7 @@ safe_acceptor(self) == /\ \E m \in msgs:
                                              refs |-> recent_msgs[self] \cup {m},
                                              lrns |-> LL] IN
                                    /\ Assert(new \in Message, 
-                                             "Failure of assertion at line 162, column 7 of macro called at line 208, column 9.")
+                                             "Failure of assertion at line 150, column 7 of macro called at line 196, column 9.")
                                    /\ \/ /\ WellFormed(new)
                                          /\ prev_msg' = [prev_msg EXCEPT ![self] = new]
                                          /\ recent_msgs' = [recent_msgs EXCEPT ![self] = {new}]
@@ -558,5 +534,5 @@ UniqueDecision ==
 
 =============================================================================
 \* Modification History
-\* Last modified Fri Nov 22 20:57:30 CET 2024 by karbyshev
+\* Last modified Mon Nov 25 16:02:54 CET 2024 by karbyshev
 \* Created Mon Jun 19 12:24:03 CEST 2022 by karbyshev

--- a/tla/HPaxos_2_proof.tla
+++ b/tla/HPaxos_2_proof.tla
@@ -8,12 +8,6 @@ LEMMA CaughtMsgSpec ==
            /\ \A X \in CaughtMsg(M) : X.type # "proposer"
 BY Tran_Message DEF CaughtMsg
 
-LEMMA CaughtMsgEffSpec ==
-    ASSUME NEW M \in Message
-    PROVE  /\ CaughtMsg0(M) \in SUBSET Message
-           /\ \A X \in CaughtMsg0(M) : X.type # "proposer"
-BY Tran_Message DEF CaughtMsg0
-
 -----------------------------------------------------------------------------
 (* Facts about Get1a, B and V relations *)
 
@@ -190,11 +184,6 @@ CaughtSpec ==
     \A AL \in SafeAcceptor \cup Learner :
         \A M \in known_msgs[AL] :
             Caught(M) \cap SafeAcceptor = {}
-
-CaughtEffSpec ==
-    \A AL \in SafeAcceptor \cup Learner :
-        \A M \in known_msgs[AL] :
-            Caught0(M) \cap SafeAcceptor = {}
 
 DecisionSpec ==
     \A L \in Learner : \A BB \in Ballot : \A VV \in Value :
@@ -1007,17 +996,10 @@ PROOF
         DEF NextTLA, SafeAcceptorAction, FakeAcceptorAction
 
 LEMMA MsgsSafeAcceptorSpecImpliesCaughtSpec ==
-    ASSUME TypeOK, KnownMsgsSpec, MsgsSafeAcceptorPrevTranLinearSpec
+    ASSUME TypeOK, KnownMsgsSpec, MsgsSafeAcceptorSpec3
     PROVE  CaughtSpec
 PROOF BY MessageSpec
-      DEF MsgsSafeAcceptorPrevTranLinearSpec, CaughtSpec, Caught, CaughtMsg,
-      KnownMsgsSpec, SentBy, OneA, TypeOK
-
-LEMMA MsgsSafeAcceptorSpecImpliesCaughtEffSpec ==
-    ASSUME TypeOK, KnownMsgsSpec, MsgsSafeAcceptorSpec3
-    PROVE  CaughtEffSpec
-PROOF BY MessageSpec
-      DEF MsgsSafeAcceptorSpec3, CaughtEffSpec, Caught0, CaughtMsg0,
+      DEF MsgsSafeAcceptorSpec3, CaughtSpec, Caught, CaughtMsg,
           KnownMsgsSpec, SentBy, OneA, TypeOK
 
 LEMMA QuorumIntersection ==
@@ -1502,5 +1484,5 @@ PROOF BY PTL, FullSafetyInvariantInit, FullSafetyInvariantNext, NextDef
 
 =============================================================================
 \* Modification History
-\* Last modified Fri Nov 22 21:00:16 CET 2024 by karbyshev
+\* Last modified Mon Nov 25 16:11:45 CET 2024 by karbyshev
 \* Created Tue Jun 20 00:28:26 CEST 2023 by karbyshev


### PR DESCRIPTION
Use Caught0 as a main definition for the caught predicate. Remove the previous definition of Caught.